### PR TITLE
Version range property

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,19 @@
 bounds-maven-plugin
 ===================
 
-A maven plugin to update the lower bounds of ranges to reduce metadata downloads
+A maven plugin to manipulate dependency ranges
+* update the lower bounds of ranges to reduce metadata downloads
+* upgrade ranges to the highest versions
+* figure out the highest version for an artifact in a range
+* figure out the next release version for this project
 
-## Example delta
-
-When you run bounds:update for a project that contains this
-
-      <plugin>
-       <groupId>net.stickycode.composite</groupId>
-       <artifactId>sticky-composite-logging-api</artifactId>
-       <version>[2.3,3)</version>
-      </plugin>
-      
-and the latest release of sticky-composite-logging-api is 2.4, then you will end up with
-
-     <plugin>
-       <groupId>net.stickycode.composite</groupId>
-       <artifactId>sticky-composite-logging-api</artifactId>
-       <version>[2.4,3)</version>
-      </plugin>
-      
-## Usage
+## Updating the lower bounds
 
 The plugin is in maven central so it should 'Just Work'.
 
 Run the plugin from your Apache Maven project directory:
 
-    mvn net.stickycode.plugins:bounds-maven-plugin:2.2:update
+    mvn net.stickycode.plugins:bounds-maven-plugin:4.7:update
 
 And your version ranges will have there lower bound updated to the latest released
 artifact version.
@@ -39,6 +25,24 @@ If you want to include any SNAPSHOT references when calculating the lower bound,
 
 when calling `mvn`.
 
+### Example of the change
+
+When you run bounds:update for a project that contains this
+
+      <dependency>
+       <groupId>net.stickycode.composite</groupId>
+       <artifactId>sticky-composite-logging-api</artifactId>
+       <version>[2.3,3)</version>
+      </dependency>
+
+and the latest release of sticky-composite-logging-api is 2.4, then you will end up with
+
+     <dependency>
+       <groupId>net.stickycode.composite</groupId>
+       <artifactId>sticky-composite-logging-api</artifactId>
+       <version>[2.4,3)</version>
+     </dependency>
+
 ### Update bounds during release
 
 To update the bounds during release you can do this
@@ -49,7 +53,7 @@ To update the bounds during release you can do this
       <plugin>
        <groupId>net.stickycode.plugins</groupId>
        <artifactId>bounds-maven-plugin</artifactId>
-       <version>3.3</version>
+       <version>4.7</version>
       </plugin>
       <plugin>
        <groupId>org.apache.maven.plugins</groupId>
@@ -69,7 +73,7 @@ You can specify the line separator used like so
       <plugin>
        <groupId>net.stickycode.plugins</groupId>
        <artifactId>bounds-maven-plugin</artifactId>
-       <version>3.3</version>
+       <version>4.7</version>
        <configuration>
         <lineSeparator>Unix</lineSeparator>
        </configuration>
@@ -77,27 +81,152 @@ You can specify the line separator used like so
 
 ## Extract Current Version
 
-To get the current version of a library from a range use bounds:current-version, this will set the property *stickyCoercion.version* to the right 2.x version
+To get the current version of a library from a range use bounds:current-version, this will set the property *sticky-coercion.version* to the latest 2.x version
 
-    <plugin>
+    <plugins>
       <plugin>
         <groupId>net.stickycode.plugins</groupId>
         <artifactId>bounds-maven-plugin</artifactId>
-        <version>3.3</version>
+        <version>4.7</version>
         <executions>
           <execution>
             <goals>
               <goal>current-version</goal>
             </goals>
             <configuration>
-              <stickyCoercion.version>net.stickycode:sticky-coercion:[2,3]</stickyCoercion.version>
+              <artifacts>
+                <artifact>net.stickycode:sticky-coercion:[2,3]</artifact>
+              </artifacts>
             </configuration>
           </execution>
         </execution>
       </plugin>
-    </plugin>
+    </plugins>
+
+
+If you want to specify a special property name you can use the coordinates syntax, this will set the *some-other-name.version* property to the latest 2.x version
+
+    <plugins>
+      <plugin>
+        <groupId>net.stickycode.plugins</groupId>
+        <artifactId>bounds-maven-plugin</artifactId>
+        <version>4.7</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>current-version</goal>
+            </goals>
+            <configuration>
+              <coordinates>
+                <some-other-name.version>net.stickycode:sticky-coercion:[2,3]</some-other-name.version>
+              </coordinates>
+            </configuration>
+          </execution>
+        </execution>
+      </plugin>
+    </plugins>
+
+## Upgrade version ranges
+
+It can be useful to upgrade all the ranges to the highest valid range, so running
+
+`mvn bounds:upgrade`
+
+will turn
+
+    <project>
+      <version>1.6-SNAPSHOT</version>
+      <dependencies>
+        <dependency>
+          <groupId>net.stickycode.composite</groupId>
+          <artifactId>sticky-composite-logging-api</artifactId>
+          <version>[2.4,3)</version>
+        </dependency>
+      </dependencies>
+    </project>
+
+into
+
+    <project>
+      <version>2.1-SNAPSHOT</version>
+      <dependencies>
+        <dependency>
+          <groupId>net.stickycode.composite</groupId>
+          <artifactId>sticky-composite-logging-api</artifactId>
+          <version>[4.7,5)</version>
+        </dependency>
+      </dependencies>
+    </project>
+
+## Next version
+
+Use the bounds:next-version mojo to derive the next likely version of this project from the already released artifacts
+
+Caveats
+* its scoped to the repositories you have configured
+* it uses metadata so if that is cached it may not pull the latest version
+
+This configuration
+
+    <project>
+      <groupId>com.example</groupId>
+      <artifactId>example-artifact</artifactId>
+      <version>1.6-SNAPSHOT</version>
+      <plugins>
+        <plugin>
+          <groupId>net.stickycode.plugins</groupId>
+          <artifactId>bounds-maven-plugin</artifactId>
+          <version>4.7</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>next-version</goal>
+              </goals>
+              <configuration>
+                <updateProjectVersion>true</updateProjectVersion>
+                <nextVersionProperty>some-property.version</nextVersionProperty>
+              </configuration>
+            </execution>
+          </execution>
+        </plugin>
+      </plugins>
+    </projects>
+
+will set **some-property.version** to the highest available version for the range com.example:example-artifact:[1,2), it will also set the *version* property of the project.
+
+### To not set the project version
+
+updateProjectVersion defaults to true to you need to set it to false to avoid setting the project version
+
+### nextVersionProperty
+
+Is optional so only set it if you wish to use the version outside of the context of the project.version
 
 ## Releases
+
+### Release 4.7
+
+* Improve bounds:current-version to set the 'artifact.versionRange' property to the range used to resolve 'artifact.version' property
+
+### Release 4.6
+
+* Bugfix current-version Reinstate **coordinates** for bounds:current-version its actually useful and breaking things is not nice for users
+
+### Release 4.1
+
+* Improve bounds:curent-version to use an artifact list and default the property to *artifactId.version*
+
+### Release 3.6
+
+* Improve bounds:upgrade Add a flag to ignore minor changes as causing a version bump, defaults to true
+
+### Release 3.5
+
+* Improve bounds:upgrade to bump the major version of the project when any of the dependencies are bumped
+
+### Release 3.4
+
+* Add bounds:upgrade to upgrade the version ranges to the highest valid range
 
 ### Release 3.3
 

--- a/src/it/current-artifact-version/pom.xml
+++ b/src/it/current-artifact-version/pom.xml
@@ -24,11 +24,36 @@
               <artifacts>
                 <artifact>net.stickycode:sticky-coercion:[2,3]</artifact>
               </artifacts>
+              <coordinates>
+                <new-coercion.version>net.stickycode:sticky-coercion:[3,4)</new-coercion.version>
+              </coordinates>
             </configuration>
           </execution>
         </executions>
       </plugin>
 
+      <plugin>
+        <groupId>com.soebes.maven.plugins</groupId>
+        <artifactId>echo-maven-plugin</artifactId>
+        <version>0.4.0</version>
+        <executions>
+          <execution>
+            <id>show-tile-configuration</id>
+            <phase>test</phase>
+            <goals>
+              <goal>echo</goal>
+            </goals>
+            <configuration>
+              <echos>
+                <echo>sticky-coercion.version: ${sticky-coercion.version}</echo>
+                <echo>sticky-coercion.versionRange: ${sticky-coercion.versionRange}</echo>
+                <echo>new-coercion.version: ${new-coercion.version}</echo>
+                <echo>new-coercion.versionRange: ${new-coercion.versionRange}</echo>
+              </echos>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/it/current-artifact-version/verify.bsh
+++ b/src/it/current-artifact-version/verify.bsh
@@ -3,16 +3,36 @@ import java.util.*;
 
 import org.codehaus.plexus.util.*;
 
-File pomFile = new File( basedir, "build.log" );
-System.out.println( "Checking for existence of first test file: " + pomFile );
-if (!pomFile.exists())
-  throw new RuntimeException(pomFile.toString() + " not found" );
+File buildLog = new File( basedir, "build.log" );
+System.out.println( "Checking for existence of first test file: " + buildLog );
+if (!buildLog.exists())
+  throw new RuntimeException(buildLog.toString() + " not found" );
 
+String logs = FileUtils.fileRead( buildLog, "UTF-8" ).trim();
 
-String pom = FileUtils.fileRead( pomFile, "UTF-8" ).trim();
+if (!logs.contains("resolved net.stickycode:sticky-coercion:jar:[2,3] to 2.7")) {
+  System.err.println("Expected version to be 2.7");
+  return false;
+}
 
-if (pom.contains("resolved net.stickycode:sticky-coercion:jar:[2,3] to 2.7"))
-	return true;
+if (!logs.contains("sticky-coercion.version: 2.7")) {
+  System.err.println("Expected property sticky-coercion.version to be 2.7");
+  return false;
+}
 
-System.err.println("Expected version to be 2.7");
-return false;
+if (!logs.contains("sticky-coercion.versionRange: [2,3]")) {
+  System.err.println("Expected property sticky-coercion.versionRange to be [2,3]");
+  return false;
+}
+
+if (!logs.contains("new-coercion.version: 3.7")) {
+  System.err.println("Expected property new-coercion.version to be 3.7");
+  return false;
+}
+
+if (!logs.contains("new-coercion.versionRange: [3,4)")) {
+  System.err.println("Expected property new-coercion.versionRange to be [3,4)");
+  return false;
+}
+
+return true;

--- a/src/main/java/net/stickycode/plugin/bounds/ArtifactLookup.java
+++ b/src/main/java/net/stickycode/plugin/bounds/ArtifactLookup.java
@@ -42,4 +42,8 @@ public class ArtifactLookup {
   public String getPropertyName() {
     return propertyName;
   }
+
+  public String getVersionRangePropertyName() {
+    return getPropertyName() + "Range";
+  }
 }

--- a/src/main/java/net/stickycode/plugin/bounds/StickyCurrentVersionMojo.java
+++ b/src/main/java/net/stickycode/plugin/bounds/StickyCurrentVersionMojo.java
@@ -94,6 +94,7 @@ public class StickyCurrentVersionMojo
   void lookupArtifactVersion(ArtifactLookup lookup) {
     Version version = highestVersion(lookup.getArtifact());
     project.getProperties().setProperty(lookup.getPropertyName(), version.toString());
+    project.getProperties().setProperty(lookup.getVersionRangePropertyName(), lookup.getArtifact().getVersion());
     log("resolved %s to %s", lookup.getArtifact(), version.toString());
   }
 


### PR DESCRIPTION
When resolving the current version for a set of artifacts also set the range used in a property.

Use case is for generating documentation around the usage of artifacts and wanting to keep the documents up to date with the latest version ranges.