### PR TITLE
Adding support for upgraded fixed ranges:

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ into
       </dependencies>
     </project>
 
+This also supports fixed ranges so [1.5.6] can be upgraded to [1.7.2] for example
+
 ## Next version
 
 Use the bounds:next-version mojo to derive the next likely version of this project from the already released artifacts
@@ -203,6 +205,10 @@ updateProjectVersion defaults to true to you need to set it to false to avoid se
 Is optional so only set it if you wish to use the version outside of the context of the project.version
 
 ## Releases
+
+### Release 4.8
+
+* Improve bounds:upgrade to also upgrade fixed ranges, this means ranges like [1.5.7] will be upgraded to the latest version
 
 ### Release 4.7
 

--- a/src/it/update-fixed/pom.xml
+++ b/src/it/update-fixed/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) 2012 RedEngine Ltd, http://www.redengine.co.nz. All rights reserved. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>net.stickycode.plugins.it</groupId>
+  <artifactId>sticky-bounds-plugin-update-fixed</artifactId>
+  <version>1.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>net.stickycode</groupId>
+      <artifactId>sticky-coercion</artifactId>
+      <version>[2.1]</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>net.stickycode.plugins</groupId>
+        <artifactId>bounds-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <configuration>
+          <lineSeparator>Mac</lineSeparator>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>update</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+</project>

--- a/src/it/update-fixed/verify.bsh
+++ b/src/it/update-fixed/verify.bsh
@@ -1,0 +1,18 @@
+import java.io.*;
+import java.util.*;
+
+import org.codehaus.plexus.util.*;
+
+File pomFile = new File( basedir, "pom.xml" );
+System.out.println( "Checking for existence of first test file: " + pomFile );
+if (!pomFile.exists())
+  throw new RuntimeException(pomFile.toString() + " not found" );
+
+
+String pom = FileUtils.fileRead( pomFile, "UTF-8" ).trim();
+
+if (pom.contains(">[2.1]<"))
+	return true;
+	
+System.err.println("Expected version to be [2.1]");
+return false;

--- a/src/it/upgrade-fixed/pom.xml
+++ b/src/it/upgrade-fixed/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) 2012 RedEngine Ltd, http://www.redengine.co.nz. All rights reserved. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>net.stickycode.plugins.it</groupId>
+  <artifactId>sticky-bounds-plugin-upgrade-fixed</artifactId>
+  <version>1.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>net.stickycode</groupId>
+      <artifactId>sticky-coercion</artifactId>
+      <version>[2.1]</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>net.stickycode.plugins</groupId>
+        <artifactId>bounds-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <configuration>
+          <lineSeparator>Mac</lineSeparator>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>upgrade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+</project>

--- a/src/it/upgrade-fixed/verify.bsh
+++ b/src/it/upgrade-fixed/verify.bsh
@@ -1,0 +1,18 @@
+import java.io.*;
+import java.util.*;
+
+import org.codehaus.plexus.util.*;
+
+File pomFile = new File( basedir, "pom.xml" );
+System.out.println( "Checking for existence of first test file: " + pomFile );
+if (!pomFile.exists())
+  throw new RuntimeException(pomFile.toString() + " not found" );
+
+
+String pom = FileUtils.fileRead( pomFile, "UTF-8" ).trim();
+
+if (pom.contains(">[6.6]<"))
+	return true;
+	
+System.err.println("Expected version to be [6.6]");
+return false;

--- a/src/main/java/net/stickycode/plugin/bounds/RangeVersionMatch.java
+++ b/src/main/java/net/stickycode/plugin/bounds/RangeVersionMatch.java
@@ -1,0 +1,62 @@
+package net.stickycode.plugin.bounds;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.maven.model.Dependency;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.version.Version;
+
+public class RangeVersionMatch {
+
+  private Pattern rangePattern = Pattern.compile("\\[[0-9\\.\\-A-Za-z]+\\s*(,\\s*[0-9\\.\\-A-Za-z]*)?\\)");
+
+  private Pattern fixedPattern = Pattern.compile("\\[(([0-9]+)[0-9\\.\\-A-Za-z]*)\\]");
+
+  private Matcher rangeMatcher;
+
+  private Matcher fixedMatcher;
+
+  private String version;
+
+  public RangeVersionMatch(String version) {
+    this.version = version;
+    this.fixedMatcher = matchFixedVersion(version);
+    this.rangeMatcher = matchVersionRange(version);
+  }
+
+  Matcher matchVersionRange(String version) {
+    return rangePattern.matcher(version);
+  }
+
+  Matcher matchFixedVersion(String version) {
+    return fixedPattern.matcher(version);
+  }
+
+  public boolean matches() {
+    return fixedMatcher.matches() || rangeMatcher.matches();
+  }
+
+  public String newVersionRange(Version highestVersion) {
+    if (fixedMatcher.matches())
+      return "[" + highestVersion + "]";
+    
+    return "[" + highestVersion.toString() + "," + majorVersionPlusOne(highestVersion) + ")";
+  }
+
+  public String getSearchRange() {
+    if (fixedMatcher.matches())
+      return "[" + fixedMatcher.group(1) + ",)";
+
+    if (rangeMatcher.matches())
+      return version.replaceFirst(rangeMatcher.group(1), ",");
+
+    throw new VersionWasNotARangeException(version);
+  }
+
+  private Integer majorVersionPlusOne(Version highestVersion) {
+    String[] split = highestVersion.toString().split("\\.");
+    return Integer.valueOf(split[0]) + 1;
+  }
+}

--- a/src/main/java/net/stickycode/plugin/bounds/StickyBoundsUpgradeMojo.java
+++ b/src/main/java/net/stickycode/plugin/bounds/StickyBoundsUpgradeMojo.java
@@ -206,7 +206,7 @@ public class StickyBoundsUpgradeMojo
 
   Artifact resolveLatestVersionRange(Dependency dependency, String version) throws MojoExecutionException {
     RangeVersionMatch versionMatch = new RangeVersionMatch(version);
-    getLog().info("Checking dependency " + dependency.getGroupId() + ":" + dependency.getArtifactId() + ":" + version);
+    getLog().debug("Checking dependency " + dependency.getGroupId() + ":" + dependency.getArtifactId() + ":" + version);
     if (versionMatch.matches()) {
       Artifact artifact = new DefaultArtifact(dependency.getGroupId(), dependency.getArtifactId(),
         dependency.getClassifier(), dependency.getType(), versionMatch.getSearchRange());
@@ -292,7 +292,7 @@ public class StickyBoundsUpgradeMojo
         : new MojoExecutionException("Failed to resolve " + artifact.toString(), v.getExceptions().get(0));
     }
 
-    getLog().info("found highest version " + v.getHighestVersion() + " in range " + artifact.getVersion());
+    getLog().debug("found highest version " + v.getHighestVersion() + " in range " + artifact.getVersion());
     return v.getHighestVersion();
   }
 

--- a/src/main/java/net/stickycode/plugin/bounds/VersionWasNotARangeException.java
+++ b/src/main/java/net/stickycode/plugin/bounds/VersionWasNotARangeException.java
@@ -1,0 +1,11 @@
+package net.stickycode.plugin.bounds;
+
+@SuppressWarnings("serial")
+public class VersionWasNotARangeException
+    extends RuntimeException {
+
+  public VersionWasNotARangeException(String version) {
+    super("Trying to derive a search range from a non range version " + version);
+  }
+
+}

--- a/src/test/java/net/stickycode/plugin/bounds/RangeVersionMatchTest.java
+++ b/src/test/java/net/stickycode/plugin/bounds/RangeVersionMatchTest.java
@@ -1,0 +1,68 @@
+package net.stickycode.plugin.bounds;
+
+import static org.assertj.core.api.StrictAssertions.assertThat;
+
+import org.apache.maven.model.Dependency;
+import org.junit.Test;
+
+public class RangeVersionMatchTest {
+
+  @Test
+  public void nomatch() {
+    assertThat(new RangeVersionMatch("1.4"));
+    assertThat(new RangeVersionMatch("1.17-SNAPSHOT"));
+  }
+
+  @Test
+  public void matchVersionRange() {
+    RangeVersionMatch mojo = new RangeVersionMatch("");
+    assertThat(mojo.matchVersionRange("[1.0,2)").matches()).isTrue();
+    assertThat(mojo.matchVersionRange("[1.0]").matches()).isFalse();
+    assertThat(mojo.matchVersionRange("[1]").matches()).isFalse();
+    assertThat(mojo.matchVersionRange("[1.2.3]").matches()).isFalse();
+    assertThat(mojo.matchVersionRange("1.0,2").matches()).isFalse();
+    assertThat(mojo.matchVersionRange("[1.0,2]").matches()).isFalse();
+    assertThat(mojo.matchVersionRange("[1.0,2.0)").matches()).isTrue();
+    assertThat(mojo.matchVersionRange("[1.0,)").matches()).isTrue();
+    assertThat(mojo.matchVersionRange("[1.0,2.3.4)").matches()).isTrue();
+    assertThat(mojo.matchVersionRange("[1.0.4,2.3.4)").matches()).isTrue();
+    assertThat(mojo.matchVersionRange("[1.0.4, 2.3.4)").matches()).isTrue();
+    assertThat(mojo.matchVersionRange("[1.0.4 , 2.3.4)").matches()).isTrue();
+    assertThat(mojo.matchVersionRange("[1.0.4 ,2.3.4)").matches()).isTrue();
+    assertThat(mojo.matchVersionRange("[1.0.4-SNAPSHOT,2.3.4-SNAPSHOT)").matches()).isTrue();
+  }
+
+  @Test
+  public void matchFixedVersion() {
+    RangeVersionMatch mojo = new RangeVersionMatch("");
+    assertThat(mojo.matchFixedVersion("[1]").matches()).isTrue();
+    assertThat(mojo.matchFixedVersion("[1.0]").matches()).isTrue();
+    assertThat(mojo.matchFixedVersion("[1.0.4]").matches()).isTrue();
+    assertThat(mojo.matchFixedVersion("[1.0.4-SNAPSHOT]").matches()).isTrue();
+    assertThat(mojo.matchFixedVersion("1.0,2").matches()).isFalse();
+    assertThat(mojo.matchFixedVersion("[1.0,2]").matches()).isFalse();
+    assertThat(mojo.matchFixedVersion("[1.0,2)").matches()).isFalse();
+    assertThat(mojo.matchFixedVersion("[1.0,2.0)").matches()).isFalse();
+    assertThat(mojo.matchFixedVersion("[1.0.4, 2.3.4)").matches()).isFalse();
+    assertThat(mojo.matchFixedVersion("[1.0.4 , 2.3.4)").matches()).isFalse();
+    assertThat(mojo.matchFixedVersion("[1.0.4 ,2.3.4)").matches()).isFalse();
+    assertThat(mojo.matchFixedVersion("[1.0.4-SNAPSHOT,2.3.4-SNAPSHOT)").matches()).isFalse();
+  }
+
+  @Test
+  public void checkSearchRange() {
+    checkSearchRange("[1,2)", "[1,)");
+    checkSearchRange("[1.0,2)", "[1.0,)");
+    checkSearchRange("[1]", "[1,)");
+    checkSearchRange("[1.2]", "[1.2,)");
+    checkSearchRange("[6.2.6]", "[6.2.6,)");
+    checkSearchRange("[1.0.2,2)", "[1.0.2,)");
+    checkSearchRange("[4,5)", "[4,)");
+    checkSearchRange("[1.0.4 ,2.3.4)", "[1.0.4 ,)");
+    checkSearchRange("[1.0.4-SNAPSHOT,2.3.4-SNAPSHOT)", "[1.0.4-SNAPSHOT,)");
+  }
+
+  private void checkSearchRange(String version, String expected) {
+    assertThat(new RangeVersionMatch(version).getSearchRange()).isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
Often compositions will fix the versions to flatten the tree, this allows one command to produce the latest composite
