### PR TITLE
Default to keeping the major version the same for fixed ranges:

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,44 @@ into
 
 This also supports fixed ranges so [1.5.6] can be upgraded to [1.7.2] for example
 
+## Upgrade fixed ranges
+
+It can be useful to upgrade all the ranges to the highest valid range, so running, 
+especially when composing third party libraries where you want to lock them down
+
+`mvn bounds:upgrade`
+
+will turn
+
+    <project>
+      <version>1.6-SNAPSHOT</version>
+      <dependencies>
+        <dependency>
+          <groupId>net.stickycode.composite</groupId>
+          <artifactId>sticky-composite-logging-api</artifactId>
+          <version>[2.4]</version>
+        </dependency>
+      </dependencies>
+    </project>
+
+into
+
+    <project>
+      <version>2.1-SNAPSHOT</version>
+      <dependencies>
+        <dependency>
+          <groupId>net.stickycode.composite</groupId>
+          <artifactId>sticky-composite-logging-api</artifactId>
+          <version>[2.9]</version>
+        </dependency>
+      </dependencies>
+    </project>
+
+Generally fixed range want to stay within the current contract i.e. [1.2.17] will upgrade to [1.2.30] or [1.3.5], 
+
+however if want to upgrade of fixed ranges to do major version bumps then you can set the flag -DallowFixedContractBumps=true 
+then [1.2.17] could be upgraded to [2.17.1]
+
 ## Next version
 
 Use the bounds:next-version mojo to derive the next likely version of this project from the already released artifacts
@@ -206,7 +244,11 @@ Is optional so only set it if you wish to use the version outside of the context
 
 ## Releases
 
-### Release 4.8
+### Release 4.11
+
+* Improve bounds:upgrade to not bump contract versions in fixed ranges unless the -DallowFixedContractBumps=true is set
+
+### Release 4.10
 
 * Improve bounds:upgrade to also upgrade fixed ranges, this means ranges like [1.5.7] will be upgraded to the latest version
 

--- a/src/it/upgrade-fixed-bump/pom.xml
+++ b/src/it/upgrade-fixed-bump/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) 2012 RedEngine Ltd, http://www.redengine.co.nz. All rights reserved. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>net.stickycode.plugins.it</groupId>
+  <artifactId>sticky-bounds-plugin-upgrade-fixed</artifactId>
+  <version>1.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>net.stickycode</groupId>
+      <artifactId>sticky-coercion</artifactId>
+      <version>[2.1]</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>net.stickycode.plugins</groupId>
+        <artifactId>bounds-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <configuration>
+          <lineSeparator>Mac</lineSeparator>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>upgrade</goal>
+            </goals>
+            <configuration>
+              <allowFixedContractBumps>true</allowFixedContractBumps>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+</project>

--- a/src/it/upgrade-fixed-bump/verify.bsh
+++ b/src/it/upgrade-fixed-bump/verify.bsh
@@ -11,8 +11,8 @@ if (!pomFile.exists())
 
 String pom = FileUtils.fileRead( pomFile, "UTF-8" ).trim();
 
-if (pom.contains(">[2.7]<"))
+if (pom.contains(">[6.6]<"))
 	return true;
 	
-System.err.println("Expected version to be [2.7]");
+System.err.println("Expected version to be [6.6]");
 return false;

--- a/src/main/java/net/stickycode/plugin/bounds/StickyBoundsUpgradeMojo.java
+++ b/src/main/java/net/stickycode/plugin/bounds/StickyBoundsUpgradeMojo.java
@@ -89,10 +89,16 @@ public class StickyBoundsUpgradeMojo
   /**
    * If bounds should be updated when there is no upgrade, useful for doing cascaded upgrades while minimising deltas
    */
-  @Parameter()
+  @Parameter(defaultValue = "false")
   private boolean acceptMinorVersionChanges = false;
 
   Changes change = new Changes();
+  
+  /**
+   * If a fixed version is defined, say [1.5.17] then most often when you upgrade its a third party library and you want [1.5.22] or [1.6.5], not [2.0.1-alpha]
+   */
+  @Parameter(defaultValue = "false")
+  private boolean allowFixedContractBumps =false;
 
   @Override
   public void execute() throws MojoExecutionException {
@@ -206,6 +212,10 @@ public class StickyBoundsUpgradeMojo
 
   Artifact resolveLatestVersionRange(Dependency dependency, String version) throws MojoExecutionException {
     RangeVersionMatch versionMatch = new RangeVersionMatch(version);
+    
+    if (allowFixedContractBumps)
+      versionMatch.allowFixedContractBump();
+    
     getLog().debug("Checking dependency " + dependency.getGroupId() + ":" + dependency.getArtifactId() + ":" + version);
     if (versionMatch.matches()) {
       Artifact artifact = new DefaultArtifact(dependency.getGroupId(), dependency.getArtifactId(),

--- a/src/test/java/net/stickycode/plugin/bounds/RangeVersionMatchTest.java
+++ b/src/test/java/net/stickycode/plugin/bounds/RangeVersionMatchTest.java
@@ -50,12 +50,19 @@ public class RangeVersionMatchTest {
   }
 
   @Test
+  public void checkSearchRangeWithBump() {
+    checkSearchRangeWithBump("[1.3.4]", "[1.3.4,)");
+    checkSearchRangeWithBump("[6]", "[6,)");
+    checkSearchRangeWithBump("[454.132]", "[454.132,)");
+  }
+
+  @Test
   public void checkSearchRange() {
     checkSearchRange("[1,2)", "[1,)");
     checkSearchRange("[1.0,2)", "[1.0,)");
-    checkSearchRange("[1]", "[1,)");
-    checkSearchRange("[1.2]", "[1.2,)");
-    checkSearchRange("[6.2.6]", "[6.2.6,)");
+    checkSearchRange("[1]", "[1,2)");
+    checkSearchRange("[1.2]", "[1.2,2)");
+    checkSearchRange("[6.2.6]", "[6.2.6,7)");
     checkSearchRange("[1.0.2,2)", "[1.0.2,)");
     checkSearchRange("[4,5)", "[4,)");
     checkSearchRange("[1.0.4 ,2.3.4)", "[1.0.4 ,)");
@@ -64,5 +71,9 @@ public class RangeVersionMatchTest {
 
   private void checkSearchRange(String version, String expected) {
     assertThat(new RangeVersionMatch(version).getSearchRange()).isEqualTo(expected);
+  }
+
+  private void checkSearchRangeWithBump(String version, String expected) {
+    assertThat(new RangeVersionMatch(version).allowFixedContractBump().getSearchRange()).isEqualTo(expected);
   }
 }


### PR DESCRIPTION
it seems in most use cases actually the fixed ranges want to maintain the contract version
