### PR TITLE
Use provided dependencies so maven 2.9.2 is happy:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,14 +30,14 @@
   </properties>
 
   <prerequisites>
-    <maven>3.5.0</maven>
+    <maven>3.6.3</maven>
   </prerequisites>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-embedder</artifactId>
-      <version>[3.5.2]</version>
+      <version>[3.6.3]</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -50,19 +50,21 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>[3.5.1]</version>
+      <version>[3.6.0]</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>[3.5.2]</version>
+      <version>[3.6.3]</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>[3.5.2]</version>
+      <version>[3.6.3]</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -78,7 +80,7 @@
       <plugin>
         <groupId>io.repaint.maven</groupId>
         <artifactId>tiles-maven-plugin</artifactId>
-        <version>2.29</version>
+        <version>2.34</version>
         <configuration>
           <tiles>
             <tile>net.stickycode.tile:sticky-tile-release:[1,2)</tile>
@@ -87,14 +89,14 @@
       </plugin>
       <plugin>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.9.0</version>
         <configuration>
           <goalPrefix>bounds</goalPrefix>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-invoker-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.5.1</version>
         <configuration>
           <projectsDirectory>src/it</projectsDirectory>
           <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
@@ -121,7 +123,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <id>purge-local-dependencies</id>


### PR DESCRIPTION
its complaining about things not being in provided scope like it actually makes it more stable at run time??
