### PR TITLE
Support invoking current-version goal via cli

### DIFF
--- a/src/it/current-version-cli/pom.xml
+++ b/src/it/current-version-cli/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright (c) 2018 RedEngine Ltd, http://www.redengine.co.nz. All rights reserved. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>net.stickycode.plugins.it</groupId>
+  <artifactId>sticky-bounds-plugin-current-version-cli</artifactId>
+  <version>1.1-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+			<phase>test</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <executable>mvn</executable>
+          <arguments>
+			<argument>net.stickycode.plugins:bounds-maven-plugin:@pom.version@:current-version</argument>
+            <argument>-Dartifact=net.stickycode:sticky-coercion:[2,3)</argument>
+          </arguments>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/current-version-cli/verify.bsh
+++ b/src/it/current-version-cli/verify.bsh
@@ -1,0 +1,23 @@
+import java.io.*;
+import java.util.*;
+
+import org.codehaus.plexus.util.*;
+
+File buildLog = new File( basedir, "build.log" );
+System.out.println( "Checking for existence of first test file: " + buildLog );
+if (!buildLog.exists())
+  throw new RuntimeException(buildLog.toString() + " not found" );
+
+String logs = FileUtils.fileRead( buildLog, "UTF-8" ).trim();
+
+if (!logs.contains("exec-maven-plugin")) {
+  System.err.println("Expected to invoke exec-maven-plugin");
+  return false;
+}
+ 
+if (!logs.contains("resolved net.stickycode:sticky-coercion:jar:[2,3) to 2.7")) {
+  System.err.println("Expected version to be 2.7");
+  return false;
+}
+
+return true;

--- a/src/main/java/net/stickycode/plugin/bounds/StickyCurrentVersionMojo.java
+++ b/src/main/java/net/stickycode/plugin/bounds/StickyCurrentVersionMojo.java
@@ -34,6 +34,13 @@ public class StickyCurrentVersionMojo
 
   @Parameter(required = false)
   private Map<String, String> coordinates;
+  
+  /**
+   * Useful when using the maven cli to look up the current version of a single artifact. Version range is 
+   * supported since the property is not split into a list.
+   */
+  @Parameter(required = false, property = "artifact")
+  private String artifact;
 
   /**
    * The artifacts to get the current version for group:artifact:version
@@ -56,9 +63,11 @@ public class StickyCurrentVersionMojo
   @Override
   public void execute()
       throws MojoExecutionException, MojoFailureException {
-
     List<ArtifactLookup> lookup = new ArrayList<>();
 
+    if (this.artifact != null)
+      lookup.add(new ArtifactLookup().withGav(this.artifact));
+    
     if (artifacts != null)
       for (String artifact : artifacts) {
         lookup.add(new ArtifactLookup().withGav(artifact));


### PR DESCRIPTION
Update the plugin to allow the following:

```bash
mvn \
  net.stickycode.plugins:bounds-maven-plugin:current-version \
  -Dartifact='org.apache.commons:commons-lang3:[3,4)'
```

This is convenient when you want to quickly see what version will be resolved for an artifact and version range. 